### PR TITLE
Fixed an issue where remotes would be transposed.

### DIFF
--- a/src/execute.js
+++ b/src/execute.js
@@ -4,12 +4,12 @@ const rimraf = require('rimraf').sync;
 const log = require('./log');
 
 module.exports = function execute(config) {
-  const gitOrigin = config.useRepo ?
+  const gitCentral = config.useRepo ?
     buildGitUrl(config.repoOrg, config.repoName, config.useHttps) : false;
   const gitFork = config.repoForkOrg ?
     buildGitUrl(config.repoForkOrg, config.repoName, config.useHttps) : false;
 
-  clone(config.techStack, gitFork, gitOrigin, config.repoName)
+  clone(config.techStack, gitFork, gitCentral, config.repoName)
     .catch(log);
 };
 
@@ -19,16 +19,41 @@ const buildGitUrl = (orgName, projectName, useHttps) =>
   `${useHttps ? HTTPS : SSH}${orgName}/${projectName}.git`;
 
 
-function clone(techStack, gitFork, gitOrigin, repoName) {
+function clone(techStack, gitFork, gitCentral, repoName) {
   // Clone the starter repo for the specified techstack and re-initialize it as
   // a new repo with correct remotes.
   const cwd = process.cwd();
   return git('clone', 'git@github.com:rangle/' + techStack, '--depth=1', repoName)
     .then(() => process.chdir(path.join(cwd, repoName)))
     .then(() => rimraf('.git'))
-    .then(() => !gitOrigin || git('init'))
-    .then(() => !gitFork || git('remote', 'add', 'upstream', gitFork))
-    .then(() => !gitOrigin || git('remote', 'add', 'origin', gitOrigin));
+    .then(() => initRepo(techStack, gitFork, gitCentral, repoName));
+}
+
+function initRepo(techStack, gitFork, gitCentral, repoName) {
+  // No repo specified - don't do any git setup.
+  if (!gitCentral) {
+    return Promise.resolve(null);
+  }
+
+  const promise = git('init');
+
+  if (gitFork) {
+    // If you specified both a central repo and a fork, we'll
+    // set origin === fork and upstream === central repo
+    // (rangle flow).
+    promise = promise
+      .then(() => git('remote', 'add', 'origin', gitFork))
+      .then(() => git('remote', 'add', 'upstream', gitCentral));
+  } else {
+    // If you specifed a central repo, but not a fork, we'll
+    // just set origin === central repo (github flow).
+    promise = promise
+      .then(() => git('remote', 'add', 'origin', gitCentral));
+  }
+
+  return promise
+    .then(() => git('add', '--all'))
+    .then(() => git('commit', '-m', `'Created ${repoName} from ${techStack}'`));
 }
 
 function git() {
@@ -52,4 +77,3 @@ function childProc(command, args) {
     });
   });
 }
-

--- a/src/inquire.js
+++ b/src/inquire.js
@@ -53,7 +53,7 @@ const REPO_NAME = {
 const USE_REPO = {
   type: 'confirm',
   name: 'useRepo',
-  message: 'Would you like to setup a Github repo for this project ?',
+  message: 'Would you like to use up a Github repo with this project ?',
   choices: [ 'Yes', 'No' ]
 };
 
@@ -68,7 +68,7 @@ const REPO_ORG = {
 
 const REPO_FORK_ORG = {
   name: 'repoForkOrg',
-  message: `Please enter your git account to create a personal fork
+  message: `Please enter your git account if you'd like to use a personal fork
 ( leave empty to skip ):`
 };
 


### PR DESCRIPTION
If you specify a central repo and a fork, `origin` should point to your fork, and `upstream` should point to the central repo.

Also adjusted the questions a little bit and added a step to make an initial commit tagged with the techstack being used.
